### PR TITLE
Master

### DIFF
--- a/ComPhy-12-GAN.ipynb
+++ b/ComPhy-12-GAN.ipynb
@@ -199,7 +199,7 @@
         "if mode == 'build':\n",
         "    gan.save(RUN_FOLDER)\n",
         "else:\n",
-        "    gan.load_weights(os.path.join(RUN_FOLDER, 'weights/weights.h5'))"
+        "    gan.load_weights(os.path.join(RUN_FOLDER, 'weights/weights.weights.h5'))"
       ],
       "execution_count": null,
       "outputs": []

--- a/models/GAN.py
+++ b/models/GAN.py
@@ -125,7 +125,7 @@ class GAN():
 
         x = generator_input
 
-        x = Dense(np.prod(self.generator_initial_dense_layer_size), kernel_initializer = self.weight_init)(x)
+        x = Dense(int(np.prod(self.generator_initial_dense_layer_size)), kernel_initializer = self.weight_init)(x)
 
         if self.generator_batch_norm_momentum:
             x = BatchNormalization(momentum = self.generator_batch_norm_momentum)(x)
@@ -263,8 +263,8 @@ class GAN():
 
             if epoch % print_every_n_batches == 0:
                 self.sample_images(run_folder)
-                self.model.save_weights(os.path.join(run_folder, 'weights/weights-%d.h5' % (epoch)))
-                self.model.save_weights(os.path.join(run_folder, 'weights/weights.h5'))
+                self.model.save_weights(os.path.join(run_folder, 'weights/weights-%d.weights.h5' % (epoch)))
+                self.model.save_weights(os.path.join(run_folder, 'weights/weights.weights.h5'))
                 self.save_model(run_folder)
 
             self.epoch += 1


### PR DESCRIPTION
Fix keras 3 compatibility issue 
- Cast Dense layer units from numpy.int64 to Python int. 
- Update save_weights filenames to comply with Keras 3 requirements (*.weights.h5).